### PR TITLE
Fix GGUF metadata parsing for 64-bit values and key order

### DIFF
--- a/toolboxes/gguf-vram-estimator.py
+++ b/toolboxes/gguf-vram-estimator.py
@@ -12,7 +12,17 @@ GGUF_MAGIC = 0x46554747
 GGUF_VALUE_TYPE = {
     0: "UINT8", 1: "INT8", 2: "UINT16", 3: "INT16", 4: "UINT32",
     5: "INT32", 6: "FLOAT32", 7: "BOOL", 8: "STRING", 9: "ARRAY",
+    10: "UINT64", 11: "INT64", 12: "FLOAT64",
 }
+SCALAR_FORMAT = {
+    0: "<B", 1: "<b", 2: "<H", 3: "<h", 4: "<I", 5: "<i",
+    6: "<f", 7: "<?", 10: "<Q", 11: "<q", 12: "<d",
+}
+ARCH_METADATA_SUFFIXES = (
+    ".block_count", ".context_length", ".attention.head_count_kv",
+    ".attention.key_length", ".attention.value_length",
+    ".attention.sliding_window_size",
+)
 
 class GGUFMetadataReader:
     """A minimal reader to get only the necessary KV metadata for cache calculation."""
@@ -36,42 +46,34 @@ class GGUFMetadataReader:
         value_type = GGUF_VALUE_TYPE.get(value_type_idx)
         if not value_type: raise ValueError(f"Unknown GGUF value type: {value_type_idx}")
         if value_type == "STRING": return self._read_string()
-        if value_type == "UINT32": return struct.unpack("<I", self.f.read(4))[0]
-        if value_type == "INT32": return struct.unpack("<i", self.f.read(4))[0]
+        scalar_format = SCALAR_FORMAT.get(value_type_idx)
+        if scalar_format:
+            return struct.unpack(scalar_format, self.f.read(struct.calcsize(scalar_format)))[0]
         self._skip_value(value_type_idx)
 
     def _skip_value(self, value_type_idx: int):
         value_type = GGUF_VALUE_TYPE.get(value_type_idx)
-        if not value_type: return
-        if value_type in ("UINT8", "INT8", "BOOL"): self.f.seek(1, 1)
-        elif value_type in ("UINT16", "INT16"): self.f.seek(2, 1)
-        elif value_type in ("UINT32", "INT32", "FLOAT32"): self.f.seek(4, 1)
+        if not value_type: raise ValueError(f"Unknown GGUF value type: {value_type_idx}")
+        scalar_format = SCALAR_FORMAT.get(value_type_idx)
+        if scalar_format:
+            self.f.seek(struct.calcsize(scalar_format), 1)
         elif value_type == "STRING":
             (length,) = struct.unpack("<Q", self.f.read(8))
             self.f.seek(length, 1)
         elif value_type == "ARRAY":
             (array_type_idx, count) = struct.unpack("<IQ", self.f.read(12))
-            type_map = {0:1, 1:1, 2:2, 3:2, 4:4, 5:4, 6:4, 7:1, 10:8, 11:8, 12:8}
-            element_size = type_map.get(array_type_idx)
-            if element_size: self.f.seek(count * element_size, 1)
+            scalar_format = SCALAR_FORMAT.get(array_type_idx)
+            if scalar_format:
+                self.f.seek(count * struct.calcsize(scalar_format), 1)
             else:
-                for _ in range(count): self._skip_value(8)
+                for _ in range(count): self._skip_value(array_type_idx)
 
     def _read_metadata(self, count: int):
-        keys_to_read = {"general.architecture", "general.name"}
-        arch_specific_keys_added = False
         for _ in range(count):
             key = self._read_string()
             (value_type_idx,) = struct.unpack("<I", self.f.read(4))
-            if not arch_specific_keys_added and "general.architecture" in self.metadata:
-                prefix = self.metadata["general.architecture"]
-                keys_to_read.update({
-                    f"{prefix}.block_count", f"{prefix}.context_length",
-                    f"{prefix}.attention.head_count_kv", f"{prefix}.attention.key_length",
-                    f"{prefix}.attention.value_length", f"{prefix}.attention.sliding_window_size"
-                })
-                arch_specific_keys_added = True
-            if key in keys_to_read:
+            # GGUF metadata is not required to put general.architecture first.
+            if key in ("general.architecture", "general.name") or key.endswith(ARCH_METADATA_SUFFIXES):
                 self.metadata[key] = self._read_value(value_type_idx)
             else:
                 self._skip_value(value_type_idx)

--- a/toolboxes/test_gguf_vram_estimator.py
+++ b/toolboxes/test_gguf_vram_estimator.py
@@ -1,0 +1,71 @@
+import importlib.util
+import struct
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("gguf-vram-estimator.py")
+SPEC = importlib.util.spec_from_file_location("gguf_vram_estimator", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def encode_string(value):
+    encoded = value.encode("utf-8")
+    return struct.pack("<Q", len(encoded)) + encoded
+
+
+def encode_value(value_type, value):
+    formats = {
+        4: "<I",
+        10: "<Q",
+        11: "<q",
+        12: "<d",
+    }
+    if value_type == 8:
+        return encode_string(value)
+    return struct.pack(formats[value_type], value)
+
+
+def write_gguf(path, metadata):
+    payload = struct.pack("<IIQQ", MODULE.GGUF_MAGIC, 3, 0, len(metadata))
+    for key, value_type, value in metadata:
+        payload += encode_string(key)
+        payload += struct.pack("<I", value_type)
+        payload += encode_value(value_type, value)
+    path.write_bytes(payload)
+
+
+class GGUFMetadataReaderTest(unittest.TestCase):
+    def read_metadata(self, metadata):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "model.gguf"
+            write_gguf(path, metadata)
+            return MODULE.GGUFMetadataReader(str(path)).read().metadata
+
+    def test_skips_64_bit_scalar_metadata_without_losing_cursor(self):
+        metadata = self.read_metadata([
+            ("general.architecture", 8, "qwen35"),
+            ("unrelated.uint64", 10, 2**40),
+            ("unrelated.int64", 11, -(2**40)),
+            ("unrelated.float64", 12, 3.5),
+            ("qwen35.block_count", 4, 40),
+        ])
+
+        self.assertEqual(metadata["qwen35.block_count"], 40)
+
+    def test_reads_architecture_metadata_that_precedes_architecture_name(self):
+        metadata = self.read_metadata([
+            ("qwen35.block_count", 4, 40),
+            ("general.architecture", 8, "qwen35"),
+            ("qwen35.context_length", 4, 262144),
+        ])
+
+        self.assertEqual(metadata["general.architecture"], "qwen35")
+        self.assertEqual(metadata["qwen35.block_count"], 40)
+        self.assertEqual(metadata["qwen35.context_length"], 262144)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- recognize the GGUF UINT64, INT64, and FLOAT64 metadata value types
- preserve the metadata cursor when skipping those scalar values
- collect architecture metadata even when it appears before `general.architecture`
- add synthetic regression fixtures for both cases

## Why

GGUF does not require `general.architecture` to precede architecture-specific fields. It also permits the 64-bit scalar types above. The estimator previously skipped neither their payloads nor architecture fields encountered early, which could corrupt subsequent parsing or leave required fields missing.

## Test

```console
$ python3 -m unittest toolboxes/test_gguf_vram_estimator.py
..
----------------------------------------------------------------------
Ran 2 tests in 0.000s

OK
```
