### PR TITLE
Install amdgpu_top in toolbox images

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -92,6 +92,7 @@ jobs:
           docker run --rm "${LI}" bash -c "if command -v llama >/dev/null; then llama version; else llama-cli --version; fi"
           docker run --rm "${LI}" llama-cli --help || { status=$?; echo "llama-cli exited with status $status"; [[ $status -eq 0 || $status -eq 1 || $status -eq 134 ]]; }
           docker run --rm "${LI}" llama-server --help || { status=$?; echo "llama-server exited with status $status"; [[ $status -eq 0 || $status -eq 1 || $status -eq 134 ]]; }
+          docker run --rm "${LI}" bash -c 'rpm -q amdgpu_top && rpm -V amdgpu_top && test -x /usr/bin/amdgpu_top'
 
           echo "→ Tag & push immutable → ${IMM}"
           docker tag "${LI}" "${IMM}"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ Use **`llama-cli`** for running models directly in your terminal—ideal for qui
 
 Use **`llama-server`** to start an OpenAI-compatible API server. This allows you to connect third-party UIs (like Open WebUI), use the built-in web interface, or build your own applications using standard libraries.
 
+Every toolbox also includes the pinned, checksum-verified `amdgpu_top` package for
+live GPU utilization, VRAM, temperature, and power monitoring. The toolbox must be
+created with `/dev/dri` passed through, as shown above. Inside the toolbox, run:
+
+```bash
+amdgpu_top
+# or the compact view:
+amdgpu_top --smi
+```
+
 **Run it (CLI Chat):**
 ```bash
 llama-cli -ngl 999 -fa 1 \

--- a/toolboxes/Dockerfile.rocm-7.14
+++ b/toolboxes/Dockerfile.rocm-7.14
@@ -19,8 +19,13 @@ RUN dnf -y --nodocs --setopt=install_weak_deps=False \
   install \
   make gcc gcc-c++ cmake libcurl-devel ninja-build \
   amdrocm-core-devel7.14-gfx1201 \
-  git-core vim sudo rsync \
+  git-core vim sudo rsync curl \
   && dnf clean all && rm -rf /var/cache/dnf/*
+
+COPY fetch-amdgpu-top-rpm.sh /tmp/fetch-amdgpu-top-rpm
+RUN chmod 0755 /tmp/fetch-amdgpu-top-rpm \
+  && /tmp/fetch-amdgpu-top-rpm /tmp/amdgpu_top.rpm \
+  && rm -f /tmp/fetch-amdgpu-top-rpm
 
 ENV ROCM_PATH=/opt/rocm \
   HIP_PATH=/opt/rocm \
@@ -58,6 +63,8 @@ RUN chmod +x /usr/local/bin/gguf-vram-estimator.py
 # runtime stage
 FROM registry.fedoraproject.org/fedora-minimal:44
 
+COPY --from=builder /tmp/amdgpu_top.rpm /tmp/amdgpu_top.rpm
+
 # ROCm 7.14 Core SDK repository (TheRock release stream)
 RUN <<'EOF'
 tee /etc/yum.repos.d/rocm.repo <<REPO
@@ -76,8 +83,9 @@ RUN microdnf -y --nodocs --setopt=install_weak_deps=0 \
   install \
   bash ca-certificates libatomic libstdc++ libgcc libgomp sudo \
   amdrocm-runtime7.14 amdrocm-blas7.14-gfx1201 \
-  radeontop procps-ng \
+  radeontop procps-ng /tmp/amdgpu_top.rpm \
   && microdnf clean all && rm -rf /var/cache/dnf/* \
+  && rm -f /tmp/amdgpu_top.rpm \
   && ln -s core-7.14 /opt/rocm/core \
   && ln -s core-7.14/bin /opt/rocm/bin \
   && ln -s core-7.14/include /opt/rocm/include \

--- a/toolboxes/Dockerfile.therock-nightly
+++ b/toolboxes/Dockerfile.therock-nightly
@@ -6,6 +6,11 @@ RUN dnf -y --nodocs --setopt=install_weak_deps=False install \
   radeontop git vim curl ninja-build tar xz aria2 \
   && dnf clean all && rm -rf /var/cache/dnf/*
 
+COPY fetch-amdgpu-top-rpm.sh /tmp/fetch-amdgpu-top-rpm
+RUN chmod 0755 /tmp/fetch-amdgpu-top-rpm \
+  && /tmp/fetch-amdgpu-top-rpm /tmp/amdgpu_top.rpm \
+  && rm -f /tmp/fetch-amdgpu-top-rpm
+
 # Fetch the latest TheRock multi-arch Linux nightly for RDNA 4 (gfx1200/gfx1201).
 WORKDIR /tmp
 ARG GFX=gfx120X-all
@@ -82,9 +87,12 @@ RUN find /opt/rocm -type f -name '*.a' -delete \
 # runtime stage
 FROM registry.fedoraproject.org/fedora-minimal:43
 
+COPY --from=builder /tmp/amdgpu_top.rpm /tmp/amdgpu_top.rpm
+
 RUN microdnf -y --nodocs --setopt=install_weak_deps=0 install \
   bash ca-certificates libatomic libstdc++ libgcc radeontop vim procps-ng \
-  && microdnf clean all && rm -rf /var/cache/dnf/*
+  /tmp/amdgpu_top.rpm \
+  && microdnf clean all && rm -rf /var/cache/dnf/* /tmp/amdgpu_top.rpm
 
 COPY --from=builder /opt/rocm /opt/rocm
 COPY --from=builder /usr/local/ /usr/local/

--- a/toolboxes/Dockerfile.vulkan-radv
+++ b/toolboxes/Dockerfile.vulkan-radv
@@ -3,11 +3,16 @@ FROM registry.fedoraproject.org/fedora:43 AS builder
 
 # deps
 RUN dnf -y --nodocs --setopt=install_weak_deps=False install \
-      git vim \
+      git vim curl \
       make gcc cmake ninja-build lld clang clang-devel compiler-rt libcurl-devel \
       vulkan-loader-devel vulkaninfo mesa-vulkan-drivers \
       spirv-headers-devel radeontop glslc \
     && dnf clean all && rm -rf /var/cache/dnf/*
+
+COPY fetch-amdgpu-top-rpm.sh /tmp/fetch-amdgpu-top-rpm
+RUN chmod 0755 /tmp/fetch-amdgpu-top-rpm \
+ && /tmp/fetch-amdgpu-top-rpm /tmp/amdgpu_top.rpm \
+ && rm -f /tmp/fetch-amdgpu-top-rpm
 
 # llama.cpp
 WORKDIR /opt/llama.cpp
@@ -39,11 +44,14 @@ RUN chmod +x /usr/local/bin/gguf-vram-estimator.py
 # runtime stage
 FROM registry.fedoraproject.org/fedora-minimal:43
 
+COPY --from=builder /tmp/amdgpu_top.rpm /tmp/amdgpu_top.rpm
+
 # runtime deps
 RUN microdnf -y --nodocs --setopt=install_weak_deps=0 install \
       bash ca-certificates libatomic libstdc++ libgcc \
       vulkan-loader vulkan-loader-devel vulkaninfo mesa-vulkan-drivers radeontop procps-ng \
-  && microdnf clean all && rm -rf /var/cache/dnf/*
+      /tmp/amdgpu_top.rpm \
+  && microdnf clean all && rm -rf /var/cache/dnf/* /tmp/amdgpu_top.rpm
 
 # copy
 COPY --from=builder /usr/ /usr/

--- a/toolboxes/fetch-amdgpu-top-rpm.sh
+++ b/toolboxes/fetch-amdgpu-top-rpm.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly DEFAULT_AMDGPU_TOP_VERSION="0.11.5"
+readonly DEFAULT_AMDGPU_TOP_SHA256="ef224f5d1c8e7621a2f309c3d465d05a18c4c660d48da5edc215c7c4e6d53e71"
+
+output_path="${1:?usage: fetch-amdgpu-top-rpm.sh OUTPUT_PATH}"
+version="${AMDGPU_TOP_VERSION:-${DEFAULT_AMDGPU_TOP_VERSION}}"
+
+if [[ "${version}" != "${DEFAULT_AMDGPU_TOP_VERSION}" && -z "${AMDGPU_TOP_SHA256:-}" ]]; then
+  printf 'AMDGPU_TOP_SHA256 is required when overriding AMDGPU_TOP_VERSION\n' >&2
+  exit 2
+fi
+
+sha256="${AMDGPU_TOP_SHA256:-${DEFAULT_AMDGPU_TOP_SHA256}}"
+if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  printf 'invalid AMDGPU_TOP_VERSION: %s\n' "${version}" >&2
+  exit 2
+fi
+if [[ ! "${sha256}" =~ ^[0-9a-f]{64}$ ]]; then
+  printf 'invalid AMDGPU_TOP_SHA256\n' >&2
+  exit 2
+fi
+
+url="https://github.com/Umio-Yasuno/amdgpu_top/releases/download/v${version}/amdgpu_top-${version}-1.x86_64.rpm"
+partial_path="${output_path}.part.$$"
+trap 'rm -f -- "${partial_path}"' EXIT
+
+curl --fail --location --silent --show-error \
+  --connect-timeout 15 --max-time 300 \
+  --retry 4 --retry-delay 2 --retry-all-errors \
+  --output "${partial_path}" "${url}"
+printf '%s  %s\n' "${sha256}" "${partial_path}" | sha256sum --check --status
+mv -- "${partial_path}" "${output_path}"
+

--- a/toolboxes/test-amdgpu-top-packaging.sh
+++ b/toolboxes/test-amdgpu-top-packaging.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+FETCHER="${SCRIPT_DIR}/fetch-amdgpu-top-rpm.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+test -x "${FETCHER}" || fail "missing executable fetch-amdgpu-top-rpm.sh"
+
+test_root="$(mktemp -d)"
+trap 'rm -rf -- "${test_root}"' EXIT
+
+rpm_path="${test_root}/amdgpu_top.rpm"
+"${FETCHER}" "${rpm_path}"
+test -s "${rpm_path}" || fail "fetcher did not create a non-empty RPM"
+
+for dockerfile in \
+  Dockerfile.vulkan-radv \
+  Dockerfile.rocm-7.14 \
+  Dockerfile.therock-nightly; do
+  path="${SCRIPT_DIR}/${dockerfile}"
+  grep -Fq '/tmp/fetch-amdgpu-top-rpm /tmp/amdgpu_top.rpm' "${path}" ||
+    fail "${dockerfile} does not fetch the pinned amdgpu_top RPM"
+  grep -Fq 'COPY --from=builder /tmp/amdgpu_top.rpm /tmp/amdgpu_top.rpm' "${path}" ||
+    fail "${dockerfile} does not copy the verified RPM into the runtime stage"
+  grep -Fq '/tmp/amdgpu_top.rpm' "${path}" ||
+    fail "${dockerfile} does not install the RPM"
+done
+
+printf 'PASS: pinned amdgpu_top packaging contract\n'


### PR DESCRIPTION
## Summary

- install the official `amdgpu_top` v0.11.5 RPM in all three toolbox images
- verify the release asset with its published SHA-256 before installation
- add image smoke checks for RPM integrity and executable presence
- document `amdgpu_top` and `amdgpu_top --smi`

The video linked from the README uses `amdgpu_top` to validate GPU allocation and
utilization, while the current images include only `radeontop`. This makes the
demonstrated monitoring workflow available inside each toolbox without requiring
an unmanaged host install.

## Verification

- `toolboxes/test-amdgpu-top-packaging.sh`
- `bash -n` and `shellcheck` on both shell scripts
- `docker build --check` for all three Dockerfiles
- RPM install and `rpm -V` on Fedora Minimal 43 and 44
- disposable Fedora 43 image on an R9700 host, with `/dev/dri` passed through:
  `amdgpu_top --list` identified three `AMD Radeon AI PRO R9700` devices and the
  integrated `AMD Radeon Graphics` device

No model process or GPU service was restarted for the device smoke test.
